### PR TITLE
Update nginx.conf (#1)

### DIFF
--- a/Pods and Containers in Kubernetes/nginx.conf
+++ b/Pods and Containers in Kubernetes/nginx.conf
@@ -1,28 +1,25 @@
-user nginx
-worker_processes auto
-
-error_log /var/log/nginx/error.log notice
-pid /var/run/nginx.pid
+worker_processes auto;
 
 events
 {
-  worker_connections 1024
+  worker_connections 1024;
 }
+
 
 http
 {
   server
   {
-    listen 80
-    server_name localhost
+    listen 80;
+    server_name localhost;
 
     location /
     {
-      root /usr/share/nginx/html
-      index index.html index.htm
+      root /usr/share/nginx/html;
+      index index.html index.htm;
     }
 
-    auth_basic "Secure Site"
-    auth_basic_user_file conf/.htpasswd
+    auth_basic "Secure Site";
+    auth_basic_user_file conf/.htpasswd;
   }
 }


### PR DESCRIPTION
the ngnix config file was malform
>kubectl logs nginx-pod nginx-container                                                                                                   git:main*
/docker-entrypoint.sh: /docker-entrypoint.d/ is not empty, will attempt to perform configuration /docker-entrypoint.sh: Looking for shell scripts in /docker-entrypoint.d/ /docker-entrypoint.sh: Launching /docker-entrypoint.d/10-listen-on-ipv6-by-default.sh 10-listen-on-ipv6-by-default.sh: info: /etc/nginx/conf.d/default.conf is not a file or does not exist /docker-entrypoint.sh: Sourcing /docker-entrypoint.d/15-local-resolvers.envsh /docker-entrypoint.sh: Launching /docker-entrypoint.d/20-envsubst-on-templates.sh /docker-entrypoint.sh: Launching /docker-entrypoint.d/30-tune-worker-processes.sh /docker-entrypoint.sh: Configuration complete; ready for start up 2023/12/29 01:31:22 [emerg] 1#1: directive "worker_processes" is not terminated by ";" in /etc/nginx/nginx.conf:4 nginx: [emerg] directive "worker_processes" is not terminated by ";" in /etc/nginx/nginx.conf:4